### PR TITLE
Add hyperid to benchmark

### DIFF
--- a/benchmark/bench.ts
+++ b/benchmark/bench.ts
@@ -1,8 +1,11 @@
 import b from 'benny'
+import hyperidFactory from 'hyperid'
 import { nanoid as nanoidJs } from 'nanoid'
 import * as uuid from 'uuid'
 
 import { nanoid as nanoidNapi } from '../index'
+
+const hyperid = hyperidFactory()
 
 async function run() {
   await b.suite(
@@ -18,6 +21,10 @@ async function run() {
 
     b.add('uuid', () => {
       uuid.v4()
+    }),
+
+    b.add('hyperid', () => {
+      hyperid()
     }),
 
     b.cycle(),

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
+    "hyperid": "^3.0.1",
     "lint-staged": "^12.1.2",
     "nanoid": "^3.3.3",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,6 +1622,14 @@ husky@^7.0.4:
   resolved "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
 
+hyperid@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hyperid/-/hyperid-3.0.1.tgz#6e9f965d79291e0465f4325568d028168b6b851b"
+  integrity sha512-I+tl7TS5nsoVhkxqX1rS3Qmqlq44eoPUcgPthW8v3IW8CvWL7lwtd6HQbkDUMrBKJTG0vgEaRsjT35imW/D+9Q==
+  dependencies:
+    uuid "^8.3.2"
+    uuid-parse "^1.1.0"
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
@@ -3261,6 +3269,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid-parse@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/uuid-parse/-/uuid-parse-1.1.0.tgz#7061c5a1384ae0e1f943c538094597e1b5f3a65b"
+  integrity sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
Hello, i looked at results and wanted to add another lib to the benchmarks.
Just to show other options. Should be also added to readme, but don't want to skew results from my machine.

https://github.com/mcollina/hyperid
```
Running "napi-nanoid" suite...
Progress: 100%

  napi-nanoid:
    8 577 220 ops/s, ±0.20%    | 73.77% slower

  js-nanoid:
    6 654 828 ops/s, ±0.26%    | 79.65% slower

  uuid:
    2 436 862 ops/s, ±0.17%    | slowest, 92.55% slower

  hyperid:
    32 702 444 ops/s, ±0.57%   | fastest

Finished 4 cases!
  Fastest: hyperid
  Slowest: uuid
✨  Done in 22.40s.
```